### PR TITLE
Fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Example using token auth:
 ```terraform
 
 module "kubectl" {
-  source  = "agseijas/kubectl-cmd/kubernetes"
+  source  = "magnolia-sre/kubectl-cmd/kubernetes"
 
   app            = "myapp"
   cluster-name   = "mycluster"
@@ -68,7 +68,7 @@ There are other auth methods (see [variables.tf # credentials](variables.tf)) yo
 
 ```terraform
 module "kubectl" {
-  source  = "agseijas/kubectl-cmd/kubernetes"
+  source  = "magnolia-sre/kubectl-cmd/kubernetes"
 
   app            = "myapp"
   cluster-name   = "mycluster"

--- a/main.tf
+++ b/main.tf
@@ -60,11 +60,12 @@ resource "null_resource" "kubectl-delete" {
     kubeconfig   = local.kubeconfig
     logfile-name = local.logfile-name
     destroy_cmd  = trim(replace(var.destroy-cmds[count.index], "kubectl", "kubectl ${local.kubectl_kubeconfig_param}"), "\n")
+    interpreter  = var.interpreter
   }
   provisioner "local-exec" {
     when        = destroy
     command     = format("%s %s", self.triggers.destroy_cmd, ">> ${self.triggers.logfile-name}-destroy-${count.index}")
-    interpreter = var.interpreter
+    interpreter = self.triggers.interpreter
     environment = {
       KUBECONFIG = base64encode(self.triggers.kubeconfig)
     }


### PR DESCRIPTION
**Problem**

12:45:58  │ Error: Invalid reference from destroy provisioner
12:45:58  │ 
12:45:58  │   on .terraform/modules/kubectl/main.tf line 67, in resource "null_resource" "kubectl-delete":
12:45:58  │   67:     interpreter = var.interpreter
12:45:58  │ 
12:45:58  │ Destroy-time provisioners and their connection configurations may only
12:45:58  │ reference attributes of the related resource, via 'self', 'count.index', or
12:45:58  │ 'each.key'.
12:45:58  │ 
12:45:58  │ References to other resources during the destroy phase can cause dependency
12:45:58  │ cycles and interact poorly with create_before_destroy.
12:45:58  ╵

**Expected**
No errors